### PR TITLE
Check Binaries Are Avaliable In New Release Script

### DIFF
--- a/release-new-version
+++ b/release-new-version
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if [[ ! -x $(which git) ]]; then
-	echo -e "\e[31m!  ERROR: Can't find the Git executable\e[00m"
-	exit 1
+  echo -e "\e[31m!  ERROR: Can't find the Git executable\e[00m"
+  exit 1
 fi
 
 if [[ ! -x $(which go) ]]; then
-	echo -e "\e[31m!  ERROR: Can't find the Go executable\e[00m"
-	exit 1
+  echo -e "\e[31m!  ERROR: Can't find the Go executable\e[00m"
+  exit 1
 fi
 
 if [ ! -z "`git status -s`" ]; then

--- a/release-new-version
+++ b/release-new-version
@@ -5,6 +5,11 @@ if [[ ! -x $(which git) ]]; then
 	exit 1
 fi
 
+if [[ ! -x $(which go) ]]; then
+	echo -e "\e[31m!  ERROR: Can't find the Go executable\e[00m"
+	exit 1
+fi
+
 if [ ! -z "`git status -s`" ]; then
   echo -e "\e[31m!  ERROR: please ensure you have added and committed all your changes first\e[00m"
   exit 1

--- a/release-new-version
+++ b/release-new-version
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ ! -x $(which git) ]]; then
+	echo -e "\e[31m!  ERROR: Can't find the Git executable\e[00m"
+	exit 1
+fi
+
 if [ ! -z "`git status -s`" ]; then
   echo -e "\e[31m!  ERROR: please ensure you have added and committed all your changes first\e[00m"
   exit 1


### PR DESCRIPTION
The `release-new-version` script assumes that you have both Git and Go available in the current PATH, added a check to make sure that is the case
